### PR TITLE
Removing snapCI

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,7 +161,6 @@
 
 - Ferramentas de Entrega Contínua
   - [GoCD](https://www.gocd.io/)
-  - [Snap CI](https://www.snap-ci.com/)
 
 # DevOps
 


### PR DESCRIPTION
SnapCI foi descontinuado, RIP! :(

Ótimo guia pessoal!